### PR TITLE
Set AAPL,ig-platform-id to 0300C89B

### DIFF
--- a/EFI/OC/config_iMac20,2_5700XT.plist
+++ b/EFI/OC/config_iMac20,2_5700XT.plist
@@ -225,7 +225,7 @@
 			<key>PciRoot(0x0)/Pci(0x2,0x0)</key>
 			<dict>
 				<key>AAPL,ig-platform-id</key>
-				<data>BwCbPg==</data>
+				<data>AwDImw==</data>
 				<key>device-id</key>
 				<data>mz4AAA==</data>
 				<key>framebuffer-con0-busid</key>
@@ -690,7 +690,8 @@
 	<key>Misc</key>
 	<dict>
 		<key>BlessOverride</key>
-		<array/>
+		<array>
+		</array>
 		<key>Boot</key>
 		<dict>
 			<key>ConsoleAttributes</key>


### PR DESCRIPTION
Tested this and allows for Final Cut Pro and Sidecar to work successfully with the iMac20,2 profile